### PR TITLE
Add CLI argument to disable a list of cogs when the bot is starting up

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,17 @@ Huskie's bot
 2. Set `DISCORD_BOT_TOKEN` in your .env file, created during the setup script, to your discord bot token
 3. `bin/run.sh`
 4. To use the Salty Bet scraper, download the chrome driver for selenium here: https://sites.google.com/a/chromium.org/chromedriver/downloads. Place driver in the `/drivers` folder
+
+### Commandline Arguments
+
+```text
+$ ./bin/run.sh --help # Or, if you have the virtual env enabled: `python run.py --help`
+usage: run.py [-h] [--disable-cogs DISABLE_COGS]
+
+Run the HuskieBot
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --disable-cogs DISABLE_COGS
+                        A list of cog module names to not enable on bot startup. Comma separted list, no spaces
+```

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 source venv/bin/activate
-python3 run.py
+python3 run.py $@

--- a/run.py
+++ b/run.py
@@ -1,4 +1,5 @@
 import argparse
+import inspect
 import logging
 import os
 import sys
@@ -45,7 +46,8 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def setup_bot():
+def setup_bot(cogs_to_disable: list) -> HuskieBot:
+    """Instantiate the bot and add default cogs."""
     bot_ = HuskieBot(
         command_prefix='!',
         description="HuskieBot is a collection of miscellaneous commands, "
@@ -68,6 +70,15 @@ def setup_bot():
         # GruNosePoster
         SaltyBet
     ]
+
+    logging.info("Disabling cogs specified from command line args")
+    for cog_to_disable in cogs_to_disable:
+        logging.debug(f'Checking if we can disable cog: {cog_to_disable}')
+        for cog_class in cog_classes:
+            if inspect.getmodule(cog_class) == cog_to_disable:
+                logging.debug(f'removing cog from cogs list: {cog_class}')
+                cog_classes.remove(cog_class)
+
     for cog_class in cog_classes:
         bot_.add_cog(cog_class(bot=bot_))
     return bot_
@@ -83,5 +94,5 @@ if __name__ == '__main__':
     args = parse_args()
     logging.debug(f'Args passed from commandline: {args}')
 
-    bot = setup_bot()
+    bot = setup_bot(args.disable_cogs)
     bot.run(os.getenv('DISCORD_BOT_TOKEN'))

--- a/run.py
+++ b/run.py
@@ -26,7 +26,10 @@ from discord_bot import HuskieBot
 def parse_cogs(cogs_list: str) -> list:
     """Parse the comma delineated string of cogs into a list of cog module names."""  # noqa # skip pylama "line too long"
     logging.debug(f'Parsing list of cogs to disable: {cogs_list}')
-    return [cog for cog in cogs_list.split(',') if getattr(sys.modules['cogs'], cog)]
+    return [*map(
+        lambda cog_name:  getattr(sys.modules['cogs'], cog_name),
+        cogs_list.split(',')
+    )]
 
 
 def parse_args() -> argparse.Namespace:

--- a/run.py
+++ b/run.py
@@ -26,10 +26,7 @@ from discord_bot import HuskieBot
 def parse_cogs(cogs_list: str) -> list:
     """Parse the comma delineated string of cogs into a list of cog module names."""  # noqa # skip pylama "line too long"
     logging.debug(f'Parsing list of cogs to disable: {cogs_list}')
-    return map(
-        lambda cog_name:  getattr(sys.modules['cogs'], cog_name),
-        cogs_list.split(',')
-    )
+    return [cog for cog in cogs_list if getattr(sys.modules['cogs'], cog)]
 
 
 def parse_args() -> argparse.Namespace:

--- a/run.py
+++ b/run.py
@@ -37,6 +37,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description='Run the HuskieBot')
 
     parser.add_argument(
+        '-d',
         '--disable-cogs',
         type=parse_cogs,
         help='A list of cog module names to not enable on bot startup. '

--- a/run.py
+++ b/run.py
@@ -26,7 +26,7 @@ from discord_bot import HuskieBot
 def parse_cogs(cogs_list: str) -> list:
     """Parse the comma delineated string of cogs into a list of cog module names."""  # noqa # skip pylama "line too long"
     logging.debug(f'Parsing list of cogs to disable: {cogs_list}')
-    return [cog for cog in cogs_list if getattr(sys.modules['cogs'], cog)]
+    return [cog for cog in cogs_list.split(',') if getattr(sys.modules['cogs'], cog)]
 
 
 def parse_args() -> argparse.Namespace:

--- a/run.py
+++ b/run.py
@@ -52,7 +52,7 @@ def setup_bot():
                     "tasks, and tools used on Michael's Discord guild"
     )
 
-    cogs = [
+    cog_classes = [
         Example,
         DungeonMaster,
         Quotes,
@@ -68,8 +68,8 @@ def setup_bot():
         # GruNosePoster
         SaltyBet
     ]
-    for cog in cogs:
-        bot_.add_cog(cog(bot=bot_))
+    for cog_class in cog_classes:
+        bot_.add_cog(cog_class(bot=bot_))
     return bot_
 
 

--- a/run.py
+++ b/run.py
@@ -49,6 +49,7 @@ def parse_args() -> argparse.Namespace:
 
 def setup_bot(cogs_to_disable: list) -> HuskieBot:
     """Instantiate the bot and add default cogs."""
+    logging.debug('Creating bot')
     bot_ = HuskieBot(
         command_prefix='!',
         description="HuskieBot is a collection of miscellaneous commands, "
@@ -72,16 +73,13 @@ def setup_bot(cogs_to_disable: list) -> HuskieBot:
         SaltyBet
     ]
 
-    logging.info("Disabling cogs specified from command line args")
-    for cog_to_disable in cogs_to_disable:
-        logging.debug(f'Checking if we can disable cog: {cog_to_disable}')
-        for cog_class in cog_classes:
-            if inspect.getmodule(cog_class) == cog_to_disable:
-                logging.debug(f'removing cog from cogs list: {cog_class}')
-                cog_classes.remove(cog_class)
-
+    logging.debug('Adding cogs to bot')
     for cog_class in cog_classes:
-        bot_.add_cog(cog_class(bot=bot_))
+        if not inspect.getmodule(cog_class) in cogs_to_disable:
+            logging.debug(f'Enabling cog {cog_class}')
+            bot_.add_cog(cog_class(bot=bot_))
+        else:
+            logging.debug(f"Skipping cog {cog_class}")
     return bot_
 
 

--- a/run.py
+++ b/run.py
@@ -1,5 +1,7 @@
+import argparse
 import logging
 import os
+import sys
 from logging.handlers import TimedRotatingFileHandler
 
 import dotenv
@@ -18,6 +20,29 @@ from cogs.salty_bet import SaltyBet
 from cogs.shutup_will import ShutupWill
 from cogs.voice import Voice
 from discord_bot import HuskieBot
+
+
+def parse_cogs(cogs_list: str) -> list:
+    """Parse the comma delineated string of cogs into a list of cog module names."""  # noqa # skip pylama "line too long"
+    logging.debug(f'Parsing list of cogs to disable: {cogs_list}')
+    return map(
+        lambda cog_name:  getattr(sys.modules['cogs'], cog_name),
+        cogs_list.split(',')
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    """Define and parse command line arguments."""
+    parser = argparse.ArgumentParser(description='Run the HuskieBot')
+
+    parser.add_argument(
+        '--disable-cogs',
+        type=parse_cogs,
+        help='A list of cog module names to not enable on bot startup. '
+             'Comma separted list, no spaces'
+    )
+
+    return parser.parse_args()
 
 
 def setup_bot():
@@ -54,6 +79,9 @@ if __name__ == '__main__':
     logging.basicConfig(level=logging.DEBUG if os.environ['ENVIRONMENT'] == 'development' else logging.INFO,
                         format='[%(asctime)s] [%(levelname)s] [%(module)s] %(message)s',
                         handlers=[handler])
+
+    args = parse_args()
+    logging.debug(f'Args passed from commandline: {args}')
 
     bot = setup_bot()
     bot.run(os.getenv('DISCORD_BOT_TOKEN'))


### PR DESCRIPTION
Add's a command line argument that accepts a comma separated list of cog module names. It parses them into a list and checks the list of cog classes that are supposed to be added to the bot. if the class is from one of the given modules, it gets removed it from the list cog classes to be added to bot.

closes #33 